### PR TITLE
Add Turn, Clue, Guess entities and update GameService #124

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/constant/EventType.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/constant/EventType.java
@@ -1,0 +1,7 @@
+package ch.uzh.ifi.hase.soprafs26.constant;
+
+public enum EventType {
+    CLUE_GIVEN,
+    CARD_REVEALED,
+    TURN_CHANGED
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/constant/GameEventType.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/constant/GameEventType.java
@@ -1,0 +1,6 @@
+package ch.uzh.ifi.hase.soprafs26.constant;
+
+public enum GameEventType {
+    CLUE,
+    GUESS
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/constant/TurnPhase.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/constant/TurnPhase.java
@@ -1,0 +1,6 @@
+package ch.uzh.ifi.hase.soprafs26.constant;
+
+public enum TurnPhase {
+    SPYMASTER_TURN,
+    SPY_TURN
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Board.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Board.java
@@ -29,4 +29,12 @@ public class Board {
 
     public List<WordCard> getCards() { return cards; }
     public void setCards(List<WordCard> cards) { this.cards = cards; }
+
+    // To be able to search for card by word
+    public WordCard findCardByWord(String word) {
+        return cards.stream()
+                .filter(card -> card.getWord().equalsIgnoreCase(word))
+                .findFirst()
+                .orElse(null);
+    }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Clue.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Clue.java
@@ -1,0 +1,16 @@
+package ch.uzh.ifi.hase.soprafs26.entity;
+
+import jakarta.persistence.*;
+
+@Entity
+public class Clue extends GameEvent {
+    private String word;
+    private int count;
+
+    public String getWord() { return word; }
+    public void setWord(String word) { this.word = word; }
+
+    public int getCount() { return count; }
+    public void setCount(int count) { this.count = count; }
+
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Game.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Game.java
@@ -5,6 +5,7 @@ import ch.uzh.ifi.hase.soprafs26.constant.TeamColor;
 import jakarta.persistence.*;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 
 @Entity
@@ -22,13 +23,21 @@ public class Game {
     @JoinColumn(name = "board_id")
     private Board board;
 
+    @OneToMany(mappedBy = "game")
+    private List<Turn> turns;
+
+    // to know which turn is currently active
+    @OneToOne
+    @JoinColumn(name = "current_turn_id")
+    private Turn currentTurn;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private GameStatus status;
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    private TeamColor currentTurn;
+    //@Enumerated(EnumType.STRING)
+    //@Column(nullable = false)
+    //private TeamColor team;
 
     private int currentRound;
     private int maxRounds;
@@ -61,11 +70,17 @@ public class Game {
     public Board getBoard() { return board; }
     public void setBoard(Board board) { this.board = board; }
 
+    public List<Turn> getTurns() { return turns; }
+    public void setTurns(List<Turn> turns) { this.turns = turns; }
+
+    public Turn getCurrentTurn() { return currentTurn; }
+    public void setCurrentTurn(Turn currentTurn) { this.currentTurn = currentTurn; }
+
     public GameStatus getStatus() { return status; }
     public void setStatus(GameStatus status) { this.status = status; }
 
-    public TeamColor getCurrentTurn() { return currentTurn; }
-    public void setCurrentTurn(TeamColor currentTurn) { this.currentTurn = currentTurn; }
+    //public TeamColor getTeam() { return team; }
+    //public void setTeam(TeamColor team) { this.team = team; }
 
     public int getCurrentRound() { return currentRound; }
     public void setCurrentRound(int currentRound) { this.currentRound = currentRound; }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/GameEvent.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/GameEvent.java
@@ -1,0 +1,40 @@
+package ch.uzh.ifi.hase.soprafs26.entity;
+
+import ch.uzh.ifi.hase.soprafs26.constant.GameEventType;
+import jakarta.persistence.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+public abstract class GameEvent {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private GameEventType type;
+
+    private LocalDateTime timeStamp;
+
+    @ManyToOne
+    private Player player;
+
+    private String description;
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public GameEventType getType() { return type; }
+    public void setType(GameEventType type) { this.type = type; }
+
+    public LocalDateTime getTimeStamp() { return timeStamp; }
+    public void setTimeStamp(LocalDateTime timeStamp) { this.timeStamp = timeStamp; }
+
+    public Player getPlayer() { return player; }
+    public void setPlayer(Player player) { this.player = player; }
+
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Guess.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Guess.java
@@ -1,0 +1,14 @@
+package ch.uzh.ifi.hase.soprafs26.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+@Entity
+public class Guess extends GameEvent {
+    @ManyToOne
+    private WordCard wordCard;
+
+    public WordCard getWordCard() { return wordCard; }
+    public void setWordCard(WordCard wordCard) { this.wordCard = wordCard; }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Turn.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Turn.java
@@ -1,0 +1,57 @@
+package ch.uzh.ifi.hase.soprafs26.entity;
+
+import ch.uzh.ifi.hase.soprafs26.constant.TeamColor;
+import ch.uzh.ifi.hase.soprafs26.constant.TurnPhase;
+import jakarta.persistence.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Entity
+@Table(name = "turn")
+public class Turn {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY) // Used when the database automatically generates the primary key using auto-increment for each new record
+    private Long id;
+
+    @ManyToOne
+    private Game game;
+
+    @Enumerated(EnumType.STRING)
+    private TeamColor currentTeamColor;
+
+    @Enumerated(EnumType.STRING)
+    private TurnPhase phase;
+    private int guessesRemaining;
+    private LocalDateTime startTime;
+
+    @OneToOne
+    private Clue clue;
+
+    @OneToMany
+    private List<Guess> guesses;
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public Game getGame() { return game; }
+    public void setGame(Game game) { this.game = game; }
+
+    public TeamColor getCurrentTeamColor() { return currentTeamColor; }
+    public void setCurrentTeamColor(TeamColor currentTeamColor) { this.currentTeamColor = currentTeamColor; }
+
+    public TurnPhase getPhase() { return phase; }
+    public void setPhase(TurnPhase phase) { this.phase = phase; }
+
+    public int getGuessesRemaining() { return guessesRemaining; }
+    public void setGuessesRemaining(int guessesRemaining) { this.guessesRemaining = guessesRemaining; }
+
+    public LocalDateTime getStartTime() { return startTime; }
+    public void setStartTime(LocalDateTime startTime) { this.startTime = startTime; }
+
+    public Clue getClue() { return clue; }
+    public void setClue(Clue clue) { this.clue = clue; }
+
+    public List<Guess> getGuesses() { return guesses; }
+    public void setGuesses(List<Guess> guesses) { this.guesses = guesses; }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/TurnRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/TurnRepository.java
@@ -1,0 +1,9 @@
+package ch.uzh.ifi.hase.soprafs26.repository;
+
+import ch.uzh.ifi.hase.soprafs26.entity.Turn;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TurnRepository extends JpaRepository<Turn, Long> {
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/ClueDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/ClueDTO.java
@@ -1,0 +1,12 @@
+package ch.uzh.ifi.hase.soprafs26.rest.dto;
+
+public class ClueDTO {
+    private String word;
+    private int count;
+
+    public String getWord() { return word; }
+    public void setWord(String word) { this.word = word; }
+
+    public int getCount() { return count; }
+    public void setCount(int count) { this.count = count; }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/GameBoardDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/GameBoardDTO.java
@@ -3,6 +3,7 @@ package ch.uzh.ifi.hase.soprafs26.rest.dto;
 import ch.uzh.ifi.hase.soprafs26.constant.CardType;
 import ch.uzh.ifi.hase.soprafs26.constant.GameStatus;
 import ch.uzh.ifi.hase.soprafs26.constant.TeamColor;
+import ch.uzh.ifi.hase.soprafs26.constant.TurnPhase;
 
 import java.util.List;
 
@@ -13,8 +14,20 @@ public class GameBoardDTO {
     private TeamColor currentTurn;
     private int redScore;
     private int blueScore;
+    private List<PlayerDTO> redTeam;
+    private List<PlayerDTO> blueTeam;
+
     private List<CardDTO> cards;
     private List<CardType> keyCard;
+
+    // Turn
+    private TurnPhase currentPhase;
+    private int guessesRemaining;
+    private long remainingTimeSeconds;
+    private String clueWord;
+    private int clueCount;
+
+
 
     public Long getId() { return id; }
     public void setId(Long id) { this.id = id; }
@@ -31,9 +44,38 @@ public class GameBoardDTO {
     public int getBlueScore() { return blueScore; }
     public void setBlueScore(int blueScore) { this.blueScore = blueScore; }
 
+    public List<PlayerDTO> getRedTeam() {
+        return redTeam;
+    }
+    public void setRedTeam(List<PlayerDTO> redTeam) {
+        this.redTeam = redTeam;
+    }
+
+    public List<PlayerDTO> getBlueTeam() {
+        return blueTeam;
+    }
+    public void setBlueTeam(List<PlayerDTO> blueTeam) {
+        this.blueTeam = blueTeam;
+    }
+
     public List<CardDTO> getCards() { return cards; }
     public void setCards(List<CardDTO> cards) { this.cards = cards; }
 
     public List<CardType> getKeyCard() { return keyCard; }
     public void setKeyCard(List<CardType> keyCard) { this.keyCard = keyCard; }
+
+    public TurnPhase getCurrentPhase() { return currentPhase; }
+    public void setCurrentPhase(TurnPhase currentPhase) { this.currentPhase = currentPhase; }
+
+    public int getGuessesRemaining() { return guessesRemaining; }
+    public void setGuessesRemaining(int guessesRemaining) { this.guessesRemaining = guessesRemaining; }
+
+    public long getRemainingTimeSeconds() { return remainingTimeSeconds; }
+    public void setRemainingTimeSeconds(long remainingTimeSeconds) { this.remainingTimeSeconds = remainingTimeSeconds; }
+
+    public String getClueWord() { return clueWord; }
+    public void setClueWord(String clueWord) { this.clueWord = clueWord; }
+
+    public int getClueCount() { return clueCount; }
+    public void setClueCount(int clueCount) {  this.clueCount = clueCount; }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/GuessDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/GuessDTO.java
@@ -1,0 +1,10 @@
+package ch.uzh.ifi.hase.soprafs26.rest.dto;
+
+import ch.uzh.ifi.hase.soprafs26.entity.WordCard;
+
+public class GuessDTO {
+    private String word;
+
+    public String getWord() { return word; }
+    public void setWord(String word) { this.word = word; }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/GameService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/GameService.java
@@ -106,6 +106,7 @@ public class GameService {
         lobbyRepository.save(lobby);
 
         // 9. Build both views and pass them to the handler
+        // TODO: optimize player list building
         GameBoardDTO spymasterBoard = buildBoardDTO(game, Role.SPYMASTER);
         GameBoardDTO operativeBoard = buildBoardDTO(game, Role.SPY);
         gameWebSocketHandler.broadcastGameStarted(lobbyCode, spymasterBoard, operativeBoard);
@@ -129,6 +130,15 @@ public class GameService {
 
 
     public GameBoardDTO buildBoardDTO(Game game, Role role) {
+        // validation
+        if(game.getLobby() == null) {
+            throw new IllegalStateException("Game not associated with a lobby");
+        }
+
+        if(game.getLobby().getPlayerList() == null) {
+            throw new IllegalStateException("Lobby has no player list");
+        }
+
         // 1. Create CardDTO
         List<CardDTO> cardDTOs = new ArrayList<>();
         List<CardType> keyCard = new ArrayList<>();
@@ -156,6 +166,7 @@ public class GameService {
         // Add team players
         List<PlayerDTO> redTeam = new ArrayList<>();
         List<PlayerDTO> blueTeam = new ArrayList<>();
+
         for (Player player : game.getLobby().getPlayerList()) {
             PlayerDTO dto = new PlayerDTO();
             dto.setId(player.getId());

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/GameService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/GameService.java
@@ -7,12 +7,14 @@ import ch.uzh.ifi.hase.soprafs26.repository.LobbyRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.TurnRepository;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.CardDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.GameBoardDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.PlayerDTO;
 import ch.uzh.ifi.hase.soprafs26.websocket.handler.GameWebSocketHandler;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -82,7 +84,6 @@ public class GameService {
         game.setStatus(GameStatus.ACTIVE);
         game.setMaxRounds(lobby.getSettings().getRounds());
 
-
         // 8. Create first turn
         Turn firstTurn = new Turn();
         firstTurn.setGame(game);
@@ -127,7 +128,7 @@ public class GameService {
     }
 
 
-    private GameBoardDTO buildBoardDTO(Game game, Role role) {
+    public GameBoardDTO buildBoardDTO(Game game, Role role) {
         // 1. Create CardDTO
         List<CardDTO> cardDTOs = new ArrayList<>();
         List<CardType> keyCard = new ArrayList<>();
@@ -151,8 +152,42 @@ public class GameService {
         boardDTO.setStatus(game.getStatus());
         boardDTO.setCurrentTurn(game.getCurrentTurn().getCurrentTeamColor());
         boardDTO.setRedScore(game.getRedScore());
+
+        // Add team players
+        List<PlayerDTO> redTeam = new ArrayList<>();
+        List<PlayerDTO> blueTeam = new ArrayList<>();
+        for (Player player : game.getLobby().getPlayerList()) {
+            PlayerDTO dto = new PlayerDTO();
+            dto.setId(player.getId());
+            dto.setUsername(player.getUsername());
+            dto.setRole(player.getRole());
+            dto.setIsHost(player.isHost());
+
+            if (player.getTeam() == TeamColor.RED) {
+                redTeam.add(dto);
+            } else {
+                blueTeam.add(dto);
+            }
+        }
+
+        boardDTO.setRedTeam(redTeam);
+        boardDTO.setBlueTeam(blueTeam);
+
         boardDTO.setBlueScore(game.getBlueScore());
         boardDTO.setCards(cardDTOs);
+
+        Turn currentTurn = game.getCurrentTurn();
+        if (currentTurn != null) {
+            boardDTO.setCurrentPhase(currentTurn.getPhase());
+            boardDTO.setGuessesRemaining(currentTurn.getGuessesRemaining());
+
+            // Calculate remaining time
+            if (currentTurn.getStartTime() != null) {
+                long elapsed = Duration.between(currentTurn.getStartTime(), LocalDateTime.now()).getSeconds();
+                long timeLimit = game.getLobby().getSettings().getTimeLimit();
+                boardDTO.setRemainingTimeSeconds(Math.max(0, timeLimit - elapsed));
+            }
+        }
 
         // 4. Only spymaster gets the key card
         if (role == Role.SPYMASTER) {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/GameService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/GameService.java
@@ -1,15 +1,10 @@
 package ch.uzh.ifi.hase.soprafs26.service;
 
-import ch.uzh.ifi.hase.soprafs26.constant.CardType;
-import ch.uzh.ifi.hase.soprafs26.constant.GameStatus;
-import ch.uzh.ifi.hase.soprafs26.constant.Role;
-import ch.uzh.ifi.hase.soprafs26.constant.TeamColor;
-import ch.uzh.ifi.hase.soprafs26.entity.Board;
-import ch.uzh.ifi.hase.soprafs26.entity.Game;
-import ch.uzh.ifi.hase.soprafs26.entity.Lobby;
-import ch.uzh.ifi.hase.soprafs26.entity.WordCard;
+import ch.uzh.ifi.hase.soprafs26.constant.*;
+import ch.uzh.ifi.hase.soprafs26.entity.*;
 import ch.uzh.ifi.hase.soprafs26.repository.GameRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.LobbyRepository;
+import ch.uzh.ifi.hase.soprafs26.repository.TurnRepository;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.CardDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.GameBoardDTO;
 import ch.uzh.ifi.hase.soprafs26.websocket.handler.GameWebSocketHandler;
@@ -18,6 +13,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -31,10 +27,12 @@ public class GameService {
     private final GameRepository gameRepository;
     private final WordService wordService;
     private final GameWebSocketHandler gameWebSocketHandler;
+    private final TurnRepository turnRepository;
 
 
-    public GameService(LobbyRepository lobbyRepository, GameRepository gameRepository, WordService wordService, GameWebSocketHandler gameWebSocketHandler) {
+    public GameService(LobbyRepository lobbyRepository, GameRepository gameRepository, WordService wordService, GameWebSocketHandler gameWebSocketHandler, TurnRepository turnRepository) {
         this.lobbyRepository = lobbyRepository;
+        this.turnRepository = turnRepository;
         this.gameRepository = gameRepository;
         this.wordService = wordService;
         this.gameWebSocketHandler = gameWebSocketHandler;
@@ -81,10 +79,24 @@ public class GameService {
         Game game = new Game();
         game.setBoard(board);
         board.setGame(game);
-
         game.setStatus(GameStatus.ACTIVE);
-        game.setCurrentTurn(TeamColor.RED);
         game.setMaxRounds(lobby.getSettings().getRounds());
+
+
+        // 8. Create first turn
+        Turn firstTurn = new Turn();
+        firstTurn.setGame(game);
+        firstTurn.setCurrentTeamColor(TeamColor.RED);
+        firstTurn.setPhase(TurnPhase.SPYMASTER_TURN);
+        firstTurn.setGuessesRemaining(0); // or don't set it up in the beginning?
+        firstTurn.setStartTime(LocalDateTime.now());
+        firstTurn.setGuesses(new ArrayList<>());
+
+        turnRepository.save(firstTurn);
+
+        game.setCurrentTurn(firstTurn);
+        game.setTurns(new ArrayList<>(List.of(firstTurn)));
+
         gameRepository.save(game);
 
         lobby.setGame(game);
@@ -92,7 +104,7 @@ public class GameService {
 
         lobbyRepository.save(lobby);
 
-        // 8. Build both views and pass them to the handler
+        // 9. Build both views and pass them to the handler
         GameBoardDTO spymasterBoard = buildBoardDTO(game, Role.SPYMASTER);
         GameBoardDTO operativeBoard = buildBoardDTO(game, Role.SPY);
         gameWebSocketHandler.broadcastGameStarted(lobbyCode, spymasterBoard, operativeBoard);
@@ -137,7 +149,7 @@ public class GameService {
         GameBoardDTO boardDTO = new GameBoardDTO();
         boardDTO.setId(game.getId());
         boardDTO.setStatus(game.getStatus());
-        boardDTO.setCurrentTurn(game.getCurrentTurn());
+        boardDTO.setCurrentTurn(game.getCurrentTurn().getCurrentTeamColor());
         boardDTO.setRedScore(game.getRedScore());
         boardDTO.setBlueScore(game.getBlueScore());
         boardDTO.setCards(cardDTOs);

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/TurnService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/TurnService.java
@@ -1,0 +1,137 @@
+package ch.uzh.ifi.hase.soprafs26.service;
+
+import ch.uzh.ifi.hase.soprafs26.constant.EventType;
+import ch.uzh.ifi.hase.soprafs26.constant.GameStatus;
+import ch.uzh.ifi.hase.soprafs26.constant.Role;
+import ch.uzh.ifi.hase.soprafs26.constant.TurnPhase;
+import ch.uzh.ifi.hase.soprafs26.entity.*;
+import ch.uzh.ifi.hase.soprafs26.repository.LobbyRepository;
+import ch.uzh.ifi.hase.soprafs26.repository.TurnRepository;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.ClueDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.GameBoardDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.GuessDTO;
+import ch.uzh.ifi.hase.soprafs26.websocket.handler.GameWebSocketHandler;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Service
+@Transactional
+public class TurnService {
+    private final LobbyRepository lobbyRepository;
+    private final GameService gameService;
+    private final GameWebSocketHandler gameWebSocketHandler;
+    private final TurnRepository turnRepository;
+
+
+    public TurnService(LobbyRepository lobbyRepository, GameService gameService, GameWebSocketHandler gameWebSocketHandler, TurnRepository turnRepository) {
+        this.lobbyRepository = lobbyRepository;
+        this.turnRepository = turnRepository;
+        this.gameService = gameService;
+        this.gameWebSocketHandler = gameWebSocketHandler;
+    }
+
+    public void submitClue(String lobbyCode, ClueDTO clueDTO) {
+        Game game = getActiveGame(lobbyCode);
+        Turn turn = getCurrentTurn(game, TurnPhase.SPYMASTER_TURN);
+
+        Clue clue = new Clue();
+        if (clueDTO.getWord() != null  && !clueDTO.getWord().isEmpty()) {
+            clue.setWord(clueDTO.getWord());
+        } else {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST , "Clue word is missing");
+        }
+        if (clueDTO.getCount() < 0) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST , "Count should be positive!");
+        } else {
+            clue.setCount(clueDTO.getCount());
+        }
+        turn.setClue(clue);
+
+        turn.setGuessesRemaining(clue.getCount() + 1);
+        turn.setPhase(TurnPhase.SPY_TURN);
+        turn.setStartTime(LocalDateTime.now());
+
+        turnRepository.save(turn);
+
+        //  Broadcast updated game state
+        GameBoardDTO spymasterView = gameService.buildBoardDTO(game, Role.SPYMASTER);
+        GameBoardDTO spyView = gameService.buildBoardDTO(game, Role.SPY);
+        gameWebSocketHandler.broadcastGameState(lobbyCode, EventType.CLUE_GIVEN, spymasterView, spyView);
+    }
+
+    public void submitGuess(String lobbyCode, GuessDTO guessDTO) {
+        Game game = getActiveGame(lobbyCode);
+        Turn turn = getCurrentTurn(game, TurnPhase.SPY_TURN);
+
+
+        // Find the card
+        WordCard wordCard = game.getBoard().findCardByWord(guessDTO.getWord());
+        if (wordCard == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST , "WordCard with word" + guessDTO.getWord() + " not exist!");
+        }
+        if (wordCard.isRevealed()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Card already revealed!");
+        }
+
+        // Reveal the card
+        wordCard.setRevealed(true);
+
+        Guess guess = new Guess();
+        guess.setWordCard(wordCard);
+        turn.getGuesses().add(guess);
+        turn.setGuessesRemaining(turn.getGuessesRemaining()- 1 );
+
+        // Check what was guessed
+        // Now try writing this part yourself:
+        // - If ASSASSIN → game over, other team wins
+        // - If correct team color → update score, continue (unless guessesRemaining == 0)
+        // - If wrong team color → update that team's score, end turn
+        // - If CIVILIAN → end turn
+
+        turnRepository.save(turn);
+
+        //  Broadcast updated game state
+        GameBoardDTO spymasterView = gameService.buildBoardDTO(game, Role.SPYMASTER);
+        GameBoardDTO spyView = gameService.buildBoardDTO(game, Role.SPY);
+        gameWebSocketHandler.broadcastGameState(lobbyCode, EventType.CLUE_GIVEN, spymasterView, spyView);
+    }
+
+    public void endTurn(String lobbyCode) {
+
+    }
+
+    private Lobby findLobbyByCode(String lobbyCode) {
+        // 1. Find the lobby
+        Optional<Lobby> lobbyOptional = lobbyRepository.findByLobbyCode(lobbyCode);
+
+        if (lobbyOptional.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Lobby not found");
+        }
+        return lobbyOptional.get();
+    }
+
+    private Game getActiveGame(String lobbyCode) {
+        Lobby lobby = findLobbyByCode(lobbyCode);
+        if (lobby.getGame() == null || lobby.getGame().getStatus() != GameStatus.ACTIVE) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Game is not active!");
+        }
+        return lobby.getGame();
+    }
+
+    private Turn getCurrentTurn(Game game, TurnPhase expectedPhase) {
+        Turn turn = game.getCurrentTurn();
+        if (turn == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "No active turn!");
+        }
+        if (turn.getPhase() != expectedPhase) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "Expected phase " + expectedPhase + " but current phase is " + turn.getPhase());
+        }
+        return turn;
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/TurnService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/TurnService.java
@@ -86,12 +86,14 @@ public class TurnService {
         turn.getGuesses().add(guess);
         turn.setGuessesRemaining(turn.getGuessesRemaining()- 1 );
 
+
+
         // Check what was guessed
         // Now try writing this part yourself:
-        // - If ASSASSIN → game over, other team wins
-        // - If correct team color → update score, continue (unless guessesRemaining == 0)
-        // - If wrong team color → update that team's score, end turn
-        // - If CIVILIAN → end turn
+        // TODO - If ASSASSIN → game over, other team wins
+        // TODO  - If correct team color → update score, continue (unless guessesRemaining == 0)
+        // TODO  - If wrong team color → update that team's score, end turn
+        // TODO  - If CIVILIAN → end turn
 
         turnRepository.save(turn);
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/websocket/event/GameEvent.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/websocket/event/GameEvent.java
@@ -32,4 +32,17 @@ public class GameEvent {
     public static GameEvent gameStarted(String lobbyCode, GameBoardDTO board){
         return new GameEvent("GAME_STARTED", lobbyCode, board);
     }
+
+    public static GameEvent clueGiven(String lobbyCode, GameBoardDTO board){
+        return new GameEvent("CLUE_GIVEN", lobbyCode, board);
+    }
+
+    public static GameEvent guessGiven(String lobbyCode, GameBoardDTO board){
+        return new GameEvent("CARD_REVEALED", lobbyCode, board);
+    }
+
+    public static GameEvent turnChanged(String lobbyCode, GameBoardDTO board){
+        return new GameEvent("TURN_CHANGED", lobbyCode, board);
+    }
+
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/websocket/handler/GameWebSocketHandler.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/websocket/handler/GameWebSocketHandler.java
@@ -1,5 +1,6 @@
 package ch.uzh.ifi.hase.soprafs26.websocket.handler;
 
+import ch.uzh.ifi.hase.soprafs26.constant.EventType;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.GameBoardDTO;
 import ch.uzh.ifi.hase.soprafs26.websocket.event.GameEvent;
 import org.slf4j.Logger;
@@ -35,6 +36,21 @@ public class GameWebSocketHandler {
         messagingTemplate.convertAndSend(
                 "/topic/game/" + lobbyCode + "/spy",
                 new GameEvent("GAME_STARTED", lobbyCode, operativeBoard)
+        );
+    }
+
+    public void broadcastGameState(String lobbyCode, EventType eventTypeE, GameBoardDTO spymasterBoard, GameBoardDTO operativeBoard) {
+        log.info("Broadcasting CLUE_GIVEN for lobby: {}", lobbyCode);
+        String eventType = eventTypeE.toString();
+
+        messagingTemplate.convertAndSend(
+                "/topic/game/" + lobbyCode + "/spymaster",
+                new GameEvent(eventType, lobbyCode, spymasterBoard)
+        );
+
+        messagingTemplate.convertAndSend(
+                "/topic/game/" + lobbyCode + "/spy",
+                new GameEvent(eventType, lobbyCode, operativeBoard)
         );
     }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/GameServiceIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/GameServiceIntegrationTest.java
@@ -46,7 +46,13 @@ public class GameServiceIntegrationTest {
         assertNotNull(game);
         assertNotNull(game.getId());
         assertEquals(GameStatus.ACTIVE, game.getStatus());
-        assertEquals(TeamColor.RED, game.getCurrentTurn());
+        assertEquals(TeamColor.RED, game.getCurrentTurn().getCurrentTeamColor());
+
+        // Check that the first turn was created correctly
+        assertNotNull(game.getCurrentTurn());
+        assertEquals(TurnPhase.SPYMASTER_TURN, game.getCurrentTurn().getPhase());
+        assertEquals(0, game.getCurrentTurn().getGuessesRemaining());
+        assertNotNull(game.getCurrentTurn().getStartTime());
 
         // Check that board has 25 cards
         assertNotNull(game.getBoard());

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/GameServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/GameServiceTest.java
@@ -1,15 +1,10 @@
 package ch.uzh.ifi.hase.soprafs26.service;
 
-import ch.uzh.ifi.hase.soprafs26.constant.CardType;
-import ch.uzh.ifi.hase.soprafs26.constant.GameStatus;
-import ch.uzh.ifi.hase.soprafs26.constant.Role;
-import ch.uzh.ifi.hase.soprafs26.constant.TeamColor;
-import ch.uzh.ifi.hase.soprafs26.entity.Board;
-import ch.uzh.ifi.hase.soprafs26.entity.Game;
-import ch.uzh.ifi.hase.soprafs26.entity.Lobby;
-import ch.uzh.ifi.hase.soprafs26.entity.WordCard;
+import ch.uzh.ifi.hase.soprafs26.constant.*;
+import ch.uzh.ifi.hase.soprafs26.entity.*;
 import ch.uzh.ifi.hase.soprafs26.repository.GameRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.LobbyRepository;
+import ch.uzh.ifi.hase.soprafs26.repository.TurnRepository;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.GameBoardDTO;
 import ch.uzh.ifi.hase.soprafs26.websocket.handler.GameWebSocketHandler;
 import org.junit.jupiter.api.BeforeEach;
@@ -42,6 +37,9 @@ class GameServiceTest {
     @Mock
     private GameRepository gameRepository;
 
+    @Mock
+    private TurnRepository turnRepository;
+
     @InjectMocks
     private GameService gameService;
 
@@ -66,6 +64,11 @@ class GameServiceTest {
             g.setId(1L);  // simulate DB auto-generated ID
             return g;
         });
+        when(turnRepository.save(any(Turn.class))).thenAnswer(invocation -> {
+           Turn t = invocation.getArgument(0);
+           t.setId(1L);
+           return t;
+        });
 
         // Call the real method we're testing
         Game game = gameService.startGame("ABC123");
@@ -75,7 +78,8 @@ class GameServiceTest {
         assertNotNull(game.getBoard());
         assertEquals(25, game.getBoard().getCards().size());
         assertEquals(GameStatus.ACTIVE, game.getStatus());
-        assertEquals(TeamColor.RED, game.getCurrentTurn());
+        assertEquals(TeamColor.RED, game.getCurrentTurn().getCurrentTeamColor());
+        assertEquals(TurnPhase.SPYMASTER_TURN, game.getCurrentTurn().getPhase());
 
         // Verify board has correct card type distribution
         // `.stream().filter().count()` goes through all 25 cards and counts how many are each type
@@ -99,6 +103,7 @@ class GameServiceTest {
         // Verify save was called
         verify(lobbyRepository).save(any(Lobby.class));
         verify(gameRepository).save(any(Game.class));
+        verify(turnRepository).save(any(Turn.class));
     }
 
     @Test
@@ -133,7 +138,11 @@ class GameServiceTest {
         Game game = new Game();
         game.setId(1L);
         game.setStatus(GameStatus.ACTIVE);
-        game.setCurrentTurn(TeamColor.RED);
+        // New
+        Turn turn = new Turn();
+        turn.setCurrentTeamColor(TeamColor.RED);
+        turn.setPhase(TurnPhase.SPYMASTER_TURN);
+        game.setCurrentTurn(turn);
 
         Board board = new Board();
         WordCard card = new WordCard();
@@ -160,7 +169,11 @@ class GameServiceTest {
         Game game = new Game();
         game.setId(1L);
         game.setStatus(GameStatus.ACTIVE);
-        game.setCurrentTurn(TeamColor.RED);
+        // New
+        Turn turn = new Turn();
+        turn.setCurrentTeamColor(TeamColor.RED);
+        turn.setPhase(TurnPhase.SPYMASTER_TURN);
+        game.setCurrentTurn(turn);
 
         Board board = new Board();
         WordCard card = new WordCard();
@@ -188,7 +201,11 @@ class GameServiceTest {
         Game game = new Game();
         game.setId(1L);
         game.setStatus(GameStatus.ACTIVE);
-        game.setCurrentTurn(TeamColor.RED);
+        // New
+        Turn turn = new Turn();
+        turn.setCurrentTeamColor(TeamColor.RED);
+        turn.setPhase(TurnPhase.SPYMASTER_TURN);
+        game.setCurrentTurn(turn);
 
         Board board = new Board();
         WordCard card = new WordCard();

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/GameServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/GameServiceTest.java
@@ -51,6 +51,7 @@ class GameServiceTest {
         testLobby.setId(1L);
         testLobby.setLobbyCode("ABC123");
         testLobby.setHostId(1L);
+
     }
 
     @Test
@@ -138,6 +139,7 @@ class GameServiceTest {
         Game game = new Game();
         game.setId(1L);
         game.setStatus(GameStatus.ACTIVE);
+        game.setLobby(testLobby);
         // New
         Turn turn = new Turn();
         turn.setCurrentTeamColor(TeamColor.RED);
@@ -169,6 +171,7 @@ class GameServiceTest {
         Game game = new Game();
         game.setId(1L);
         game.setStatus(GameStatus.ACTIVE);
+        game.setLobby(testLobby);
         // New
         Turn turn = new Turn();
         turn.setCurrentTeamColor(TeamColor.RED);
@@ -201,6 +204,7 @@ class GameServiceTest {
         Game game = new Game();
         game.setId(1L);
         game.setStatus(GameStatus.ACTIVE);
+        game.setLobby(testLobby);
         // New
         Turn turn = new Turn();
         turn.setCurrentTeamColor(TeamColor.RED);

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/TurnServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/TurnServiceTest.java
@@ -1,0 +1,183 @@
+package ch.uzh.ifi.hase.soprafs26.service;
+
+import ch.uzh.ifi.hase.soprafs26.constant.GameStatus;
+import ch.uzh.ifi.hase.soprafs26.constant.Role;
+import ch.uzh.ifi.hase.soprafs26.constant.TurnPhase;
+import ch.uzh.ifi.hase.soprafs26.entity.Game;
+import ch.uzh.ifi.hase.soprafs26.entity.Lobby;
+import ch.uzh.ifi.hase.soprafs26.entity.Turn;
+import ch.uzh.ifi.hase.soprafs26.repository.LobbyRepository;
+import ch.uzh.ifi.hase.soprafs26.repository.TurnRepository;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.ClueDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.GameBoardDTO;
+import ch.uzh.ifi.hase.soprafs26.websocket.handler.GameWebSocketHandler;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.junit.jupiter.api.Test;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class TurnServiceTest {
+
+    @Mock
+    private LobbyRepository lobbyRepository;
+    @Mock
+    private GameService gameService;
+    @Mock
+    private GameWebSocketHandler gameWebSocketHandler;
+    @Mock
+    private TurnRepository turnRepository;
+
+    @InjectMocks
+    private TurnService turnService;
+
+    private Lobby testLobby;
+    private Game testGame;
+    private Turn testTurn;
+
+    @BeforeEach
+    public void setup() {
+        testTurn = new Turn();
+        testTurn.setPhase(TurnPhase.SPYMASTER_TURN);
+
+        testGame = new Game();
+        testGame.setStatus(GameStatus.ACTIVE);
+        testGame.setCurrentTurn(testTurn);
+
+        testLobby = new Lobby();
+        testLobby.setLobbyCode("ABC123");
+        testLobby.setGame(testGame);
+    }
+
+    @Test
+    public void submitClue_validClue_success() {
+        // Setup
+        when(lobbyRepository.findByLobbyCode("ABC123")).thenReturn(Optional.of(testLobby));
+        when(turnRepository.save(any(Turn.class))).thenReturn(testTurn);
+        when(gameService.buildBoardDTO(any(Game.class), eq(Role.SPYMASTER))).thenReturn(new GameBoardDTO());
+        when(gameService.buildBoardDTO(any(Game.class), eq(Role.SPY))).thenReturn(new GameBoardDTO());
+
+        ClueDTO clueDTO = new ClueDTO();
+        clueDTO.setWord("animal");
+        clueDTO.setCount(3);
+
+        // Act
+        turnService.submitClue("ABC123", clueDTO);
+
+        // Assert
+        assertEquals(TurnPhase.SPY_TURN, testTurn.getPhase());
+        assertEquals(4, testTurn.getGuessesRemaining()); // count + 1
+        assertNotNull(testTurn.getClue());
+        assertEquals("animal", testTurn.getClue().getWord());
+        assertEquals(3, testTurn.getClue().getCount());
+        assertNotNull(testTurn.getStartTime());
+
+        // Verify saves and broadcasts happened
+        verify(turnRepository).save(testTurn);
+        verify(gameWebSocketHandler).broadcastGameState(
+                eq("ABC123"), any(), any(GameBoardDTO.class), any(GameBoardDTO.class));
+    }
+
+    @Test
+    public void submitClue_emptyWord_throwsBadRequest() {
+        when(lobbyRepository.findByLobbyCode("ABC123")).thenReturn(Optional.of(testLobby));
+
+        ClueDTO clueDTO = new ClueDTO();
+        clueDTO.setWord("");
+        clueDTO.setCount(3);
+
+        ResponseStatusException exception = assertThrows(
+                ResponseStatusException.class, () -> turnService.submitClue("ABC123", clueDTO));
+
+        assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
+        verify(turnRepository, never()).save(any());
+    }
+
+    @Test
+    public void submitClue_nullWord_throwsBadRequest() {
+        when(lobbyRepository.findByLobbyCode("ABC123")).thenReturn(Optional.of(testLobby));
+
+        ClueDTO clueDTO = new ClueDTO();
+        clueDTO.setWord(null);
+        clueDTO.setCount(3);
+
+        ResponseStatusException exception = assertThrows(
+                ResponseStatusException.class, () -> turnService.submitClue("ABC123", clueDTO));
+
+        assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
+        verify(turnRepository, never()).save(any());
+    }
+
+    @Test
+    public void submitClue_negativeCount_throwsBadRequest() {
+        when(lobbyRepository.findByLobbyCode("ABC123")).thenReturn(Optional.of(testLobby));
+
+        ClueDTO clueDTO = new ClueDTO();
+        clueDTO.setWord("animal");
+        clueDTO.setCount(-1);
+
+        ResponseStatusException exception = assertThrows(
+                ResponseStatusException.class, () -> turnService.submitClue("ABC123", clueDTO));
+
+        assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
+        verify(turnRepository, never()).save(any());
+    }
+
+    @Test
+    public void submitClue_gameNotActive_throwsBadRequest() {
+        testGame.setStatus(GameStatus.FINISHED);
+        when(lobbyRepository.findByLobbyCode("ABC123")).thenReturn(Optional.of(testLobby));
+
+        ClueDTO clueDTO = new ClueDTO();
+        clueDTO.setWord("animal");
+        clueDTO.setCount(3);
+
+        ResponseStatusException exception = assertThrows(
+                ResponseStatusException.class, () -> turnService.submitClue("ABC123", clueDTO));
+
+        assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
+        verify(turnRepository, never()).save(any());
+    }
+
+    @Test
+    public void submitClue_wrongPhase_throwsBadRequest() {
+        testTurn.setPhase(TurnPhase.SPY_TURN);
+        when(lobbyRepository.findByLobbyCode("ABC123")).thenReturn(Optional.of(testLobby));
+
+        ClueDTO clueDTO = new ClueDTO();
+        clueDTO.setWord("animal");
+        clueDTO.setCount(3);
+
+        ResponseStatusException exception = assertThrows(
+                ResponseStatusException.class, () -> turnService.submitClue("ABC123", clueDTO));
+
+        assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
+        verify(turnRepository, never()).save(any());
+    }
+
+    @Test
+    public void submitClue_lobbyNotFound_throwsNotFound() {
+        when(lobbyRepository.findByLobbyCode("INVALID")).thenReturn(Optional.empty());
+
+        ClueDTO clueDTO = new ClueDTO();
+        clueDTO.setWord("animal");
+        clueDTO.setCount(3);
+
+        ResponseStatusException exception = assertThrows(
+                ResponseStatusException.class, () -> turnService.submitClue("INVALID", clueDTO));
+
+        assertEquals(HttpStatus.NOT_FOUND, exception.getStatusCode());
+        verify(turnRepository, never()).save(any());
+    }
+}


### PR DESCRIPTION
- Create Turn entity with fields: currentTeamColor, phase, guessesRemaining, startTime, clue, guesses
- Create GameEvent base entity with SINGLE_TABLE inheritance
- Create Clue entity (extends GameEvent) with word, count
- Create Guess entity (extends GameEvent) with wordCard
- Create TurnRepository
- Update GameService.startGame() to create first Turn
- Update GameService.buildBoardDTO() to get team color from Turn
- Fix unit and integration tests for new Turn structure